### PR TITLE
サブスク停止アルバム対策

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -51,6 +51,10 @@ class AlbumsController < ApplicationController
   def show
     begin
       @album = Album.lookup(params[:id])
+      if @album.nil?
+        flash[:danger] = "アルバムの配信が停止されています。"
+        redirect_back(fallback_location: root_path)
+      end
     rescue SocketError => e
       flash.now[:danger] = "再試行してください。"
     rescue JSON::ParserError => e


### PR DESCRIPTION
apple musicで配信が停止したアルバムに対して、情報が見つからずにエラーが発生するバグを修正しました。