### PR TITLE
アルバム順解消、テスト順検索結果表示

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -38,7 +38,6 @@ class LikesController < ApplicationController
                        .order('match_score DESC')
                        .tap do |users|
                         users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
                           user.i_like = @like_user_ids.include?(user.id)
                           user.i_liked = liked_user_ids.include?(user.id)
                           user.notification_now = notification_user_ids.include?(user.id)
@@ -57,7 +56,6 @@ class LikesController < ApplicationController
                        .order('albums_count DESC')
                        .tap do |users|
                         users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
                           user.i_like = @like_user_ids.include?(user.id)
                           user.i_liked = liked_user_ids.include?(user.id)
                           user.notification_now = notification_user_ids.include?(user.id)
@@ -91,7 +89,6 @@ class LikesController < ApplicationController
         .order('match_score DESC')
         .tap do |users|
          users.each do |user|
-           user.user_albums = user.user_albums.sort_by(&:order_number)
            user.i_like = like_user_ids.include?(user.id)
            user.i_liked = @liked_user_ids.include?(user.id)
            user.notification_now = notification_user_ids.include?(user.id)
@@ -110,7 +107,6 @@ class LikesController < ApplicationController
         .order('albums_count DESC')
         .tap do |users|
          users.each do |user|
-           user.user_albums = user.user_albums.sort_by(&:order_number)
            user.i_like = like_user_ids.include?(user.id)
            user.i_liked = @liked_user_ids.include?(user.id)
            user.notification_now = notification_user_ids.include?(user.id)
@@ -145,7 +141,6 @@ class LikesController < ApplicationController
         .order('match_score DESC')
         .tap do |users|
          users.each do |user|
-           user.user_albums = user.user_albums.sort_by(&:order_number)
            user.i_like = like_user_ids.include?(user.id)
            user.i_liked = liked_user_ids.include?(user.id)
            user.notification_now = notification_user_ids.include?(user.id)
@@ -164,7 +159,6 @@ class LikesController < ApplicationController
         .order('albums_count DESC')
         .tap do |users|
          users.each do |user|
-           user.user_albums = user.user_albums.sort_by(&:order_number)
            user.i_like = like_user_ids.include?(user.id)
            user.i_liked = liked_user_ids.include?(user.id)
            user.notification_now = notification_user_ids.include?(user.id)

--- a/app/controllers/other_users_controller.rb
+++ b/app/controllers/other_users_controller.rb
@@ -161,7 +161,6 @@ class OtherUsersController < ApplicationController
                        .order('match_score DESC')
                        .tap do |users|
                         users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
                           user.i_like = like_user_ids.include?(user.id)
                           user.i_liked = liked_user_ids.include?(user.id)
                           user.notification_now = notification_user_ids.include?(user.id)
@@ -183,7 +182,6 @@ class OtherUsersController < ApplicationController
                        .order('albums_count DESC')
                        .tap do |users|
                         users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
                           user.i_like = like_user_ids.include?(user.id)
                           user.i_liked = liked_user_ids.include?(user.id)
                           user.notification_now = notification_user_ids.include?(user.id)
@@ -199,9 +197,6 @@ class OtherUsersController < ApplicationController
                                 (SELECT COUNT(*) FROM user_albums WHERE user_id = users.id) AS album_count')
                        .group('users.id')
                        .order('albums_count DESC')
-                       .tap do |users|
-                        users.each { |user| user.user_albums = user.user_albums.sort_by(&:order_number) }
-                      end
     end
 
     @other_users = @other_users.left_joins(:areas).where(areas: { id: params[:areas_name] }) if params[:areas_name].present?
@@ -234,7 +229,6 @@ class OtherUsersController < ApplicationController
                        .order('max_rank_score DESC')
                        .tap do |users|
                         users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
                           user.i_like = like_user_ids.include?(user.id)
                           user.i_liked = liked_user_ids.include?(user.id)
                           user.notification_now = notification_user_ids.include?(user.id)
@@ -254,7 +248,6 @@ class OtherUsersController < ApplicationController
                        .order('max_rank_score DESC')
                        .tap do |users|
                         users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
                           user.i_like = like_user_ids.include?(user.id)
                           user.i_liked = liked_user_ids.include?(user.id)
                           user.notification_now = notification_user_ids.include?(user.id)
@@ -268,18 +261,12 @@ class OtherUsersController < ApplicationController
                        .select('users.*, COALESCE(MAX(CASE WHEN results.clear = true THEN results.rank_score ELSE NULL END), 0) AS max_rank_score, 
                                 (SELECT COUNT(*) FROM user_albums WHERE user_id = users.id) AS album_count') # clearがtrueのrank_scoreのみ取得
                        .order('max_rank_score DESC')
-                       .tap do |users|
-                        users.each do |user|
-                          user.user_albums = user.user_albums.sort_by(&:order_number)
-                        end
-                      end
-
     end
 
-    @other_users = @other_users.joins(:areas).where(areas: { id: params[:areas_name] }) if params[:areas_name].present?
+    @other_users = @other_users.left_joins(:areas).where(areas: { id: params[:areas_name] }) if params[:areas_name].present?
 
     if params[:instruments_name].present?
-      @other_users = @other_users.joins(:instruments).where(instruments: { id: params[:instruments_name] })
+      @other_users = @other_users.left_joins(:instruments).where(instruments: { id: params[:instruments_name] })
     end
 
     return unless params[:purpose].present?
@@ -445,6 +432,6 @@ class OtherUsersController < ApplicationController
       url: "https://metronote.jp/other_users/#{@user.id}?time=#{current_time}",
       image: "https://#{ENV['AWS_BUCKET_NAME']}.s3.us-east-1.amazonaws.com/album_grid_#{@user.id}_#{current_time}.png"
     }
-    @user_albums = @user.user_albums.includes(:album).order(order_number: :asc)
+    @user_albums = @user.user_albums.includes(:album)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -26,7 +26,7 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    @user_albums = current_user.user_albums.includes(:album).order(order_number: :asc)
+    @user_albums = current_user.user_albums.includes(:album)
   end
 
   private

--- a/app/models/user_album.rb
+++ b/app/models/user_album.rb
@@ -1,4 +1,5 @@
 class UserAlbum < ApplicationRecord
   belongs_to :user
   belongs_to :album
+  default_scope { order(order_number: :asc) }
 end

--- a/app/views/albums/_album_user.html.erb
+++ b/app/views/albums/_album_user.html.erb
@@ -9,7 +9,7 @@
       <span class="lg:text-2xl max-lg:sm"><%= album_user.name %></span>
     </div>
     <div class="grid grid-cols-3  rounded overflow-hidden">
-      <% album_user.user_albums.includes(:album).order(order_number: :asc).each do |user_album| %>
+      <% album_user.user_albums.includes(:album).each do |user_album| %>
         <%= link_to album_path(user_album.album.itunes_album_id) do %>
           <div class="album w-40 h-40 overflow-hidden flex items-center justify-center max-lg:w-12 max-lg:h-12">
             <%= image_tag user_album.album.artwork_url, class: "object-cover w-full h-full" %>

--- a/app/views/other_users/index.html.erb
+++ b/app/views/other_users/index.html.erb
@@ -13,7 +13,7 @@
         <div class="fixed">
           <div class="flex justify-between lg:text-2xl">
             <div class="lg:mr-64 max-lg:mr-12 sort-text-on">マッチ順</div>
-            <%= link_to "テスト順", quiz_result_other_users_path, class: "sort-text-off" %>
+            <%= link_to "テスト順", quiz_result_other_users_path(params.permit(:q, :areas_name, :instruments_name, :purpose)), class: "sort-text-off" %>
          </div>
         </div>
       </div>

--- a/app/views/other_users/quiz_result.html.erb
+++ b/app/views/other_users/quiz_result.html.erb
@@ -8,20 +8,22 @@
     <% unless @other_users.present? %>
       <div class="neon-text-on-no-link lg:text-2xl lg:right-1/2 lg:fixed max-lg:mt-6 max-lg:text-center">条件に合うユーザーはいませんでした。</div>
     <% end %>
-    <div class="flex justify-center">
-      <div class="fixed">
-        <div class="flex justify-between lg:text-2xl">
-          <%= link_to "マッチ順", root_path, class: "sort-text-off" %>
-          <div class="lg:ml-64 max-lg:ml-12 sort-text-on">テスト順</div>
+    <% if @other_users.present? %>
+      <div class="flex justify-center">
+        <div class="fixed">
+          <div class="flex justify-between lg:text-2xl">
+            <%= link_to "マッチ順", root_path(params.permit(:q, :areas_name, :instruments_name, :purpose)), class: "sort-text-off" %>
+            <div class="lg:ml-64 max-lg:ml-12 sort-text-on">テスト順</div>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
     <div class="mt-12">
       <%= render partial: 'other_user', collection: @other_users %>
     </div>
   </div>
   <div class=" lg:items-end lg:p-2 max-lg:pt-2 search-menu max-lg:hidden search-back-root">
-    <%= search_form_for @q, url: other_users_path, method: :get do |f| %>
+    <%= search_form_for @q, url: quiz_result_other_users_path, method: :get do |f| %>
       <div>
         <%= f.search_field :name_cont, value: params.dig(:q, :name_cont), placeholder: "ユーザー名", class: "input-field fixed lg:right-8 w-80 z-10 lg:mt-6 max-lg:left-1/2 max-lg:transform max-lg:-translate-x-1/2",autocomplete: 'off', 'data-no-auto-focus': 'true' %>
       </div>


### PR DESCRIPTION
n+1問題が発生しないように、アルバムの順番を並び替えて表示するようにロジックを変更しました。
テスト結果順においても検索結果を適応できるようにしました。